### PR TITLE
Cache changes

### DIFF
--- a/Source/Components/ComponentDataAccess.cst
+++ b/Source/Components/ComponentDataAccess.cst
@@ -176,7 +176,7 @@
 		/// <param name="_cachePolicy">The Entity Caching policy</param>
 		/// <returns>Returns a generic collection of <%=className%> objects from cache.</returns>
 		[DataObjectMethod(DataObjectMethodType.Select)]
-		<%= constructorAccessModifier %> <%=collectionClassName%> <%=partialClassInternalPrefix%>GetCacheBy<%=GetKeysName(fkeys[j].ForeignKeyMemberColumns)%>(<%= GetFunctionHeaderParameters(fkeys[j].ForeignKeyMemberColumns) %>, <%= GetCacheFunctionParameters(DotNetVersion) %>)
+		<%= constructorAccessModifier %> <%=collectionClassName%> <%=partialClassInternalPrefix%>GetBy<%=GetKeysName(fkeys[j].ForeignKeyMemberColumns)%>(<%= GetFunctionHeaderParameters(fkeys[j].ForeignKeyMemberColumns) %>, <%= GetCacheFunctionParameters(DotNetVersion) %>)
 		{
 
 			#region Security check
@@ -190,7 +190,7 @@
 			
             #region Cache
             
-            string cacheKey = new System.Text.StringBuilder("<%=abstractClassName%>.<%=partialClassInternalPrefix%>GetCacheBy<%=GetKeysName(fkeys[j].ForeignKeyMemberColumns)%>")<% foreach(ColumnSchema col in fkeys[j].ForeignKeyMemberColumns) { %>.Append("|<%=GetFieldName(col)%>|").Append(<%=GetFieldName(col)%>)<% } %>.ToString();
+            string cacheKey = new System.Text.StringBuilder("<%=abstractClassName%>.<%=partialClassInternalPrefix%>GetBy<%=GetKeysName(fkeys[j].ForeignKeyMemberColumns)%>")<% foreach(ColumnSchema col in fkeys[j].ForeignKeyMemberColumns) { %>.Append("|<%=GetFieldName(col)%>|").Append(<%=GetFieldName(col)%>)<% } %>.ToString();
 
             if (_cacheOptions == EntityCacheOptions.UpdateCache || _cacheOptions == EntityCacheOptions.RemoveFromCache)
             {
@@ -386,7 +386,7 @@
 		/// <param name="_cachePolicy">The Entity Caching policy</param>
 		/// <returns>Returns an instance of the <see cref="<%= returnTypeForComment %>"/> class.</returns>
 		[DataObjectMethod(DataObjectMethodType.Select)]
-		<%= constructorAccessModifier %> <%=returnType%> <%=partialClassInternalPrefix%>GetCacheBy<%=GetKeysName(indexes[j].MemberColumns)%>(<%= GetFunctionHeaderParameters(indexes[j].MemberColumns) %>, <%= GetCacheFunctionParameters(DotNetVersion) %>)
+		<%= constructorAccessModifier %> <%=returnType%> <%=partialClassInternalPrefix%>GetBy<%=GetKeysName(indexes[j].MemberColumns)%>(<%= GetFunctionHeaderParameters(indexes[j].MemberColumns) %>, <%= GetCacheFunctionParameters(DotNetVersion) %>)
 		{
 			#region Security check
 			// throws security exception if not authorized
@@ -399,7 +399,7 @@
 			
             #region Cache
             
-            string cacheKey = new System.Text.StringBuilder("<%=abstractClassName%>.<%=partialClassInternalPrefix%>GetCacheBy<%=GetKeysName(indexes[j].MemberColumns)%>")<% foreach(ColumnSchema col in indexes[j].MemberColumns) { %>.Append("|<%=GetFieldName(col)%>|").Append(<%=GetFieldName(col)%>)<% } %>.ToString();
+            string cacheKey = new System.Text.StringBuilder("<%=abstractClassName%>.<%=partialClassInternalPrefix%>GetBy<%=GetKeysName(indexes[j].MemberColumns)%>")<% foreach(ColumnSchema col in indexes[j].MemberColumns) { %>.Append("|<%=GetFieldName(col)%>|").Append(<%=GetFieldName(col)%>)<% } %>.ToString();
 
             if (_cacheOptions == EntityCacheOptions.UpdateCache || _cacheOptions == EntityCacheOptions.RemoveFromCache)
             {
@@ -534,7 +534,7 @@
 		/// <param name="_cacheOptions">General features directing what the caching method is doing</param>
 		/// <param name="_cachePolicy">The Entity Caching policy</param>
 		/// <returns></returns>
-		<%= constructorAccessModifier %> <%=collectionClassName %> <%=partialClassInternalPrefix%>GetCacheAll(<%= GetCacheFunctionParameters(DotNetVersion) %>) 
+		<%= constructorAccessModifier %> <%=collectionClassName %> <%=partialClassInternalPrefix%><%= MethodNames.GetAll %>(<%= GetCacheFunctionParameters(DotNetVersion) %>) 
 		{
 			#region Security check
 			// throws security exception if not authorized

--- a/Source/Components/ComponentDataAccess.cst
+++ b/Source/Components/ComponentDataAccess.cst
@@ -21,6 +21,8 @@
 <%@ Property Name="UsePartialClass" Type="System.Boolean" Default="true" Category="General" Description="Indicates if partial class should be generated." %>
 <%@ Property Name="RenderOverload" Type="System.Boolean" Default="False" Category="Options" Description="If true the overloaded methods will be generated." %>
 <%@ Property Name="RenderImplementation" Type="System.Boolean" Default="False" Category="Options" Description="If true the implementation methods will be generated." %>
+<%@ Property Name="CreateEntityCache" Optional="True" Type="System.Boolean" Default="False" Category="Options" Description="Should Caching be enabled for this entity." %>
+<%@ Property Name="DotNetVersion" Type="MoM.Templates.DotNetFrameworkVersion" Default="v4_5" Category="02. Framework Generation - Optional" Description="Indicates the Version of Dot Net to target. Options include v2, v3 and v3.5" %>
 
 <%
 
@@ -160,6 +162,63 @@
 					
 				getbyKeys.Add(GetKeysName(fkeys[j].ForeignKeyMemberColumns));
 		%>	
+        
+    	<% if(CreateEntityCache) {%>
+		/// <summary>
+        ///     Checks and creates cache first.
+		/// 	<%= constructorAccessModifier %> method that Gets rows in a <see cref="<%=collectionClassNameComment %>" /> from the datasource based on the <%=fkeys[j].Name%> key.
+		///		<%=fkeys[j].Name%> Description: <%=GetColumnXmlComment(fkeys[j],2)%>
+		/// </summary>
+		<% for (int i = 0; i < fkeys[j].ForeignKeyMemberColumns.Count; i++) { %>
+		/// <param name="<%= GetFieldName(fkeys[j].ForeignKeyMemberColumns[i])%>"><%=GetColumnXmlComment(fkeys[j].ForeignKeyMemberColumns[i],2)%></param>
+		<% } %>
+		/// <param name="_cacheOptions">General features directing what the caching method is doing</param>
+		/// <param name="_cachePolicy">The Entity Caching policy</param>
+		/// <returns>Returns a generic collection of <%=className%> objects from cache.</returns>
+		[DataObjectMethod(DataObjectMethodType.Select)]
+		<%= constructorAccessModifier %> <%=collectionClassName%> <%=partialClassInternalPrefix%>GetCacheBy<%=GetKeysName(fkeys[j].ForeignKeyMemberColumns)%>(<%= GetFunctionHeaderParameters(fkeys[j].ForeignKeyMemberColumns) %>, <%= GetCacheFunctionParameters(DotNetVersion) %>)
+		{
+
+			#region Security check
+			// throws security exception if not authorized
+			SecurityContext.IsAuthorized("GetBy<%=GetKeysName(fkeys[j].ForeignKeyMemberColumns)%>");
+			#endregion Security check
+			
+			#region Initialisation
+			<%= collectionClassName %> list = null;
+			#endregion Initialisation
+			
+            #region Cache
+            
+            string cacheKey = new System.Text.StringBuilder("<%=abstractClassName%>.<%=partialClassInternalPrefix%>GetCacheBy<%=GetKeysName(fkeys[j].ForeignKeyMemberColumns)%>")<% foreach(ColumnSchema col in fkeys[j].ForeignKeyMemberColumns) { %>.Append("|<%=GetFieldName(col)%>|").Append(<%=GetFieldName(col)%>)<% } %>.ToString();
+
+            if (_cacheOptions == EntityCacheOptions.UpdateCache || _cacheOptions == EntityCacheOptions.RemoveFromCache)
+            {
+                EntityCache.RemoveItem(cacheKey);
+
+                if (_cacheOptions == EntityCacheOptions.RemoveFromCache)
+                    return null;
+            }
+            else
+            {
+                list = EntityCache.GetItem<<%=collectionClassName%>>(cacheKey.ToString());
+                if (list != null)
+                {
+                    return list;
+                }
+            }
+            
+            #endregion
+            
+            list = <%=partialClassInternalPrefix%>GetBy<%=GetKeysName(fkeys[j].ForeignKeyMemberColumns)%>(<%= GetFunctionCallParameters(fkeys[j].ForeignKeyMemberColumns) %>);
+
+            if (list != null && list.Count > 0)
+                EntityCache.AddCache(cacheKey, list, _cachePolicy);
+				
+			return list;
+		}
+        <% } %>
+        
 		/// <summary>
 		/// 	<%= constructorAccessModifier %> method that Gets rows in a <see cref="<%=collectionClassNameComment %>" /> from the datasource based on the <%=fkeys[j].Name%> key.
 		///		<%=fkeys[j].Name%> Description: <%=GetColumnXmlComment(fkeys[j],2)%>
@@ -183,6 +242,8 @@
 			NetTiersProvider dataProvider = null;
 			#endregion Initialisation
 			
+            
+            
 			try
             {					
 				transactionManager = ConnectionScope.ValidateOrCreateTransaction(noTranByDefault);
@@ -313,6 +374,60 @@
 				string returnTypeForComment = returnType.Replace("<", "{").Replace(">", "}");
 		%>
 
+    	<% if(CreateEntityCache) {%>
+		/// <summary>
+        ///  Enable Caching on index
+		///  method that Gets rows in a <see cref="<%=collectionClassNameComment %>" /> from the datasource based on the primary key <%=indexes[j].Name%> index.
+		/// </summary>
+		<% for (int i = 0; i < indexes[j].MemberColumns.Count; i++) { %>
+		/// <param name="<%= GetFieldName(indexes[j].MemberColumns[i])%>"><%=GetColumnXmlComment( indexes[j].MemberColumns[i],2)%></param>
+		<% } %>
+		/// <param name="_cacheOptions">General features directing what the caching method is doing</param>
+		/// <param name="_cachePolicy">The Entity Caching policy</param>
+		/// <returns>Returns an instance of the <see cref="<%= returnTypeForComment %>"/> class.</returns>
+		[DataObjectMethod(DataObjectMethodType.Select)]
+		<%= constructorAccessModifier %> <%=returnType%> <%=partialClassInternalPrefix%>GetCacheBy<%=GetKeysName(indexes[j].MemberColumns)%>(<%= GetFunctionHeaderParameters(indexes[j].MemberColumns) %>, <%= GetCacheFunctionParameters(DotNetVersion) %>)
+		{
+			#region Security check
+			// throws security exception if not authorized
+			SecurityContext.IsAuthorized("GetBy<%=GetKeysName(indexes[j].MemberColumns)%>");
+			#endregion Security check
+			
+			#region Initialisation
+			<%=returnType%> <%= returnTypeVar %> = null;
+			#endregion Initialisation
+			
+            #region Cache
+            
+            string cacheKey = new System.Text.StringBuilder("<%=abstractClassName%>.<%=partialClassInternalPrefix%>GetCacheBy<%=GetKeysName(indexes[j].MemberColumns)%>")<% foreach(ColumnSchema col in indexes[j].MemberColumns) { %>.Append("|<%=GetFieldName(col)%>|").Append(<%=GetFieldName(col)%>)<% } %>.ToString();
+
+            if (_cacheOptions == EntityCacheOptions.UpdateCache || _cacheOptions == EntityCacheOptions.RemoveFromCache)
+            {
+                EntityCache.RemoveItem(cacheKey);
+
+                if (_cacheOptions == EntityCacheOptions.RemoveFromCache)
+                    return null;
+            }
+            else
+            {
+                <%= returnTypeVar %> = EntityCache.GetItem<<%=returnType%>>(cacheKey.ToString());
+                if (<%= returnTypeVar %> != null)
+                {
+                    return <%= returnTypeVar %>;
+                }
+            }
+            
+            #endregion
+            
+            <%= returnTypeVar %> = <%=partialClassInternalPrefix%>GetBy<%=GetKeysName(indexes[j].MemberColumns)%>(<%= GetFunctionCallParameters(indexes[j].MemberColumns) %>);
+
+            if (<%= returnTypeVar %> != null)
+                EntityCache.AddCache(cacheKey, <%= returnTypeVar %>, _cachePolicy);
+				
+			return <%= returnTypeVar %>;
+		}
+		<% } %>
+		
 		/// <summary>
 		///  method that Gets rows in a <see cref="<%=collectionClassNameComment %>" /> from the datasource based on the primary key <%=indexes[j].Name%> index.
 		/// </summary>
@@ -409,7 +524,60 @@
 	
 		<% if (IncludeGetList) { %>
 		#region <%=partialClassInternalPrefix%><%= MethodNames.GetAll %>
-		/// <summary>
+
+    	<% if(CreateEntityCache) {%>
+
+        /// <summary>
+		/// Get a complete collection of <see cref="<%= className %>" /> entities.
+        /// With Caching enabled.
+		/// </summary>
+		/// <param name="_cacheOptions">General features directing what the caching method is doing</param>
+		/// <param name="_cachePolicy">The Entity Caching policy</param>
+		/// <returns></returns>
+		<%= constructorAccessModifier %> <%=collectionClassName %> <%=partialClassInternalPrefix%>GetCacheAll(<%= GetCacheFunctionParameters(DotNetVersion) %>) 
+		{
+			#region Security check
+			// throws security exception if not authorized
+			SecurityContext.IsAuthorized("<%= MethodNames.GetAll %>");
+			#endregion Security check
+			
+			#region Initialisation
+			<%= collectionClassName %> list = null;
+			#endregion Initialisation
+
+            #region Cache
+            
+            string cacheKey = "<%=abstractClassName %>.<%=partialClassInternalPrefix%><%= MethodNames.GetAll %>";
+
+            if (_cacheOptions == EntityCacheOptions.UpdateCache || _cacheOptions == EntityCacheOptions.RemoveFromCache)
+            {
+                EntityCache.RemoveItem(cacheKey);
+
+                if (_cacheOptions == EntityCacheOptions.RemoveFromCache)
+                    return null;
+            }
+            else
+            {
+                list = EntityCache.GetItem<<%= collectionClassName %>>(cacheKey.ToString());
+                if (list != null)
+                {
+                    return list;
+                }
+            }
+            
+            #endregion
+            
+            list = <%=partialClassInternalPrefix%><%= MethodNames.GetAll %>();
+
+            if (list != null && list.Count > 0)
+                EntityCache.AddCache(cacheKey, list, _cachePolicy);
+				
+			return list;
+		}
+
+		<% } %>
+
+        /// <summary>
 		/// Get a complete collection of <see cref="<%= className %>" /> entities.
 		/// </summary>
 		/// <returns></returns>
@@ -1238,7 +1406,72 @@
 		%>
 		
 		#region <%=command.Name%>
+    	<% if(CreateEntityCache && returnType != "void") {%>
 		/// <summary>
+		///	This method wrap the '<%=command.Name%>' stored procedure. 
+        /// Adds a caching layer to this custom sproc.
+		/// </summary><%=TransformStoredProcedureInputsToMethodComments(command.InputParameters) + TransformStoredProcedureOutputsToMethodComments(command.AllOutputParameters)%>
+		/// <param name="_cacheOptions">General features directing what the caching method is doing</param>
+		/// <param name="_cachePolicy">The Entity Caching policy</param>
+		/// <remark>This method is generate from a stored procedure.</remark><% if (returnType != "void") {%>
+		/// <returns>A <see cref="<%=returnTypeForComment%>"/> instance.</returns><%}%>
+		<%= constructorAccessModifier %>  <%=returnType%> <%=methodName%>(<%= (parms.Length > 0 ? parms.TrimStart(',') + "," : "") %> <%= GetCacheFunctionParameters(DotNetVersion) %>)
+		{
+			#region Security check
+			// throws security exception if not authorized
+			SecurityContext.IsAuthorized("<%=methodName%>");
+			#endregion Security check
+		
+			#region Initialisation
+			<%= string.Format("{0} result = null;" , returnType) %> 
+			#endregion Initialisation
+			
+			try
+            {
+                #region Cache
+                
+                string cacheKey = new System.Text.StringBuilder("<%=abstractClassName%>.<%=methodName%>")<% foreach(var col in command.InputParameters) { %>.Append("|<%=GetFieldName(col)%>|").Append(<%=GetFieldName(col)%>)<% } %><% foreach(var col in command.AllOutputParameters) { %>.Append("|<%=GetFieldName(col)%>|").Append(<%=GetFieldName(col)%>)<% } %>.ToString();
+
+                if (_cacheOptions == EntityCacheOptions.UpdateCache || _cacheOptions == EntityCacheOptions.RemoveFromCache)
+                {
+                    EntityCache.RemoveItem(cacheKey);
+
+                    if (_cacheOptions == EntityCacheOptions.RemoveFromCache)
+                        return null;
+                }
+                else
+                {
+                    result = EntityCache.GetItem<<%=returnType%>>(cacheKey.ToString());
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+                
+                #endregion
+                
+                result = <%=methodName%>(<%=TransformStoredProcedureInputsToDataAccess(false, command.InputParameters) + TransformStoredProcedureOutputsToDataAccess(true, command.AllOutputParameters)%>)<%= newCollectionEnd %>;
+
+                if (result != null)
+                    EntityCache.AddCache(cacheKey, result, _cachePolicy);
+    				
+			}
+            catch (Exception exc)
+            {
+				#region Handle transaction rollback and exception
+				
+				//Handle exception based on policy
+                if (DomainUtil.HandleException(exc, layerExceptionPolicy)) 
+					throw;
+                    
+				#endregion Handle transaction rollback and exception
+            }
+			
+			return result;
+		}
+        <% } %>
+        
+        /// <summary>
 		///	This method wrap the '<%=command.Name%>' stored procedure. 
 		/// </summary><%=TransformStoredProcedureInputsToMethodComments(command.InputParameters) + TransformStoredProcedureOutputsToMethodComments(command.AllOutputParameters)%>
 		/// <remark>This method is generate from a stored procedure.</remark><% if (returnType != "void") {%>

--- a/Source/Components/ComponentServiceBase.cst
+++ b/Source/Components/ComponentServiceBase.cst
@@ -20,6 +20,7 @@
 
 <%@ Property Name="SourceTable" Type="SchemaExplorer.TableSchema" Category="Connection" Description="Table Object should be based on." %>
 <%@ Property Name="SourceTables" Type="SchemaExplorer.TableSchemaCollection" Category="Connection" Description="Tables of the sytem." %>
+<%@ Property Name="CreateEntityCache" Optional="True" Type="System.Boolean" Default="False" Category="Options" Description="Should Caching be enabled for this entity." %>
 
 <%@ Property Name="IncludeRelations" Type="System.Boolean" Default="True" Category="Options" Description="Include Collections for Related Entities."%>
 <%@ Property Name="IncludeCustoms" Type="System.Boolean" Default="True" Category="Options" Description="If true customs stored procedures will be generated as functions." %>

--- a/Source/Entities/EntityCache.cst
+++ b/Source/Entities/EntityCache.cst
@@ -140,7 +140,7 @@ namespace <%=NameSpace%>
         /// <summary>
         /// Just a standard cache retrieval call, apply Policy if provided and the item does not yet exist in cache.
         /// </summary>
-        None,
+        Cache,
         /// <summary>
         /// Refresh the data in the cache.
         /// </summary>

--- a/Source/Entities/EntityCache.cst
+++ b/Source/Entities/EntityCache.cst
@@ -1,21 +1,12 @@
 ﻿<%--
- * $Id: EntityHelper.cst,v 1.3 2006/02/09 23:35:10 goofsr Exp $
- * Last modified by $Author: goofsr $
- * Last modified at $Date: 2006/02/09 23:35:10 $
- * $Revision: 1.3 $
+ * $Id: EntityHelper.cst,v 1.0 2017/01/01 23:35:10 jguenther Exp $
+ * Last modified by $Author: jguenther $
+ * Last modified at $Date: 2017/01/01 23:35:10 $
+ * $Revision: 1.0 $
 --%>
 <%@ CodeTemplate Language="C#" TargetLanguage="C#" Description="contains a creational factory for entity types." ResponseEncoding="UTF-8"  NoWarn="0108,0618,1572,1573,1574,0162,2002"%>
 <%@ Property Name="NameSpace" Type="System.String" Category="Data" Description="The project root Namespace." %>
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-using Microsoft.Practices.EnterpriseLibrary.Common;
-using Microsoft.Practices.EnterpriseLibrary.Caching;
-using Microsoft.Practices.EnterpriseLibrary.Caching.Configuration;
-using Microsoft.Practices.EnterpriseLibrary.Caching.BackingStoreImplementations;
-using Microsoft.Practices.EnterpriseLibrary.Common.Configuration;
-using Microsoft.Practices.EnterpriseLibrary.Caching.Cryptography.Configuration;
+using System.Runtime.Caching;
 
 namespace <%=NameSpace%>
 {
@@ -24,121 +15,26 @@ namespace <%=NameSpace%>
     /// </summary>
     public static class EntityCache
     {
-        private static volatile CacheManagerFactory cacheManagerFactory;
-        private static volatile CacheManager cacheManager;
+        private static volatile MemoryCache cacheManager;
         private static string cacheManagerKey = "<%=NameSpace%>.EntityCache";
 		private static object syncObject = new object(); 
-		private static string configurationFile;
         
 		/// <summary>
         /// Gets the cache manager.
         /// </summary>
         /// <value>The cache manager.</value>		
-        public static CacheManager CacheManager
+        public static MemoryCache CacheManager
         {
-            get{
+            get
+            {
                 if (cacheManager == null)
-                    cacheManager = (CacheManager) CacheManagerFactory.Create(cacheManagerKey);
-
+                    cacheManager = new MemoryCache(CacheManagerKey);
+                
                 return cacheManager;
              }
         }
         
-		/// <summary>
-        /// Generates the configuration.
-        /// </summary>
-        /// <returns>DictionaryConfigurationSource to Configure the cache</returns>
-        internal static DictionaryConfigurationSource GenerateConfiguration()
-        {
-            DictionaryConfigurationSource sections = new DictionaryConfigurationSource();
-            sections.Add(CacheManagerSettings.SectionName, GenerateDefaultCacheManagerSettings());
-            return sections;
-        }
-
-		#region GenerateDefaultCacheManagerSettings
-        /// <summary>
-        /// Generates the default cache manager settings.
-        /// </summary>
-        /// <returns></returns>
-		private static CacheManagerSettings GenerateDefaultCacheManagerSettings()
-        {
-            CacheManagerSettings settings = new CacheManagerSettings();
-            settings.BackingStores.Add(new CacheStorageData("inMemoryWithEncryptor", typeof(NullBackingStore), "dpapiEncryptor"));
-            settings.EncryptionProviders.Add(new SymmetricStorageEncryptionProviderData("dpapiEncryptor", "dpapi1"));
-            settings.CacheManagers.Add(
-                new CacheManagerData(cacheManagerKey,
-                        10000, //Polling time
-                        1000, //Items to store
-                        100, //Items to remove 
-                        "inMemoryWithEncryptor"));
-            return settings;
-        }
-		#endregion 
-	    
-		#region ConfigurationFile
-		/// <summary>
-        /// Gets or sets the configuration file.
-        /// </summary>
-        /// <value>The configuration file.</value>
-        public static string ConfigurationFile
-		{
-			get
-			{ 	
-			    return configurationFile; 
-			}
-			set
-			{
-			    lock(syncObject)    
-			        configurationFile = value;
-			}
-		}
-		#endregion 
-		
-        #region CacheManagerFactory
-		/// <summary>
-        /// Gets or sets the cache manager factory.
-        /// </summary>
-        /// <value>The cache manager factory.</value>
-        public static CacheManagerFactory CacheManagerFactory
-        {
-            get {
-            	    if (cacheManagerFactory == null)
-					{
-						lock(syncObject)
-						{
-							IConfigurationSource configurationSource = null;
-							//From specified config
-							if (ConfigurationFile != null && System.IO.File.Exists(ConfigurationFile))
-							{
-								 configurationSource = new FileConfigurationSource(ConfigurationFile);
-                                 cacheManagerFactory = new CacheManagerFactory(configurationSource);
-							}
-							else
-                            {
-                                try
-                                {
-                                    //Try reading from default Configuration Source web/app config
-                                    IConfigurationSource userConfiguration = new SystemConfigurationSource();
-                                    cacheManagerFactory = new CacheManagerFactory(userConfiguration);
-									
-									//Test if CacheManagerKey is Configured
-                                    cacheManagerFactory.Create(CacheManagerKey);
-                                }
-                                catch(Exception)
-                                {
-                                    // Currently not configured, generate configuration
-                                    configurationSource = GenerateConfiguration();
-                                    cacheManagerFactory = new CacheManagerFactory(configurationSource);
-                                }
-							}
-						}
-					}
-                    return cacheManagerFactory; 
-                }
-            set { cacheManagerFactory = value; }
-        }
-		#endregion 
-		
+	
 		#region CacheManagerKey
 		/// <summary>
 	    /// Assigns the Default CacheManagerKey To Be Used.
@@ -176,6 +72,7 @@ namespace <%=NameSpace%>
         /// </summary>
         public static void FlushCacheManager()
         {
+            CacheManager.Dispose();
             cacheManager = null;
         }
 
@@ -184,33 +81,73 @@ namespace <%=NameSpace%>
         /// </summary>
         public static void FlushCache()
         {
-            CacheManager.Flush();
+            CacheManager.Dispose();
+            cacheManager = null;
         }
-        #endregion 
-	
-		#region AddCache
-		/// <summary>
-        /// Adds the cache.
+        #endregion
+
+        #region AddCache
+
+        /// <summary>
+        /// Adds the cache without a policy.
         /// </summary>
         /// <param name="id">The id.</param>
         /// <param name="entity">The entity.</param>
         public static void AddCache(string id, object entity)
         {
-            CacheManager.Add(id, entity);
+            CacheManager.Add(id, entity, null);
         }
-		#endregion 
-	
-		#region GetItem
+
+        /// <summary>
+        /// Adds the cache.
+        /// </summary>
+        /// <param name="id">The id.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="_cachePolicy">The entity caching policy.</param>
+        public static void AddCache(string id, object entity, EntityCachePolicy _cachePolicy)
+        {
+            CacheManager.Add(id, entity, _cachePolicy);
+        }
+        #endregion
+
+        #region GetItem
         /// <summary>
         /// Gets the item.
         /// </summary>
         /// <param name="id">The id.</param>
         /// <returns></returns> 
-		public static T GetItem<T>(string id) where T : class
+        public static T GetItem<T>(string id) where T : class
         {
-            return CacheManager.GetData(id) as T;    
+            return CacheManager[id] as T;
         }
         #endregion
-    
-	}
+
+    }
+
+    /// <summary>
+    /// Policy wrapper class
+    /// </summary>
+    public class EntityCachePolicy : CacheItemPolicy
+    {
+
+    }
+
+    /// <summary>
+    /// General features directing what the caching method is doing
+    /// </summary>
+    public enum EntityCacheOptions
+    {
+        /// <summary>
+        /// Just a standard cache retrieval call, apply Policy if provided and the item does not yet exist in cache.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Refresh the data in the cache.
+        /// </summary>
+        UpdateCache,
+        /// <summary>
+        /// Remove this key from the cache.
+        /// </summary>
+        RemoveFromCache
+    }
 }

--- a/Source/Entities/EntityCache_EntLib.cst
+++ b/Source/Entities/EntityCache_EntLib.cst
@@ -1,0 +1,256 @@
+﻿<%--
+ * $Id: EntityHelper.cst,v 1.3 2006/02/09 23:35:10 goofsr Exp $
+ * Last modified by $Author: goofsr $
+ * Last modified at $Date: 2006/02/09 23:35:10 $
+ * $Revision: 1.3 $
+--%>
+<%@ CodeTemplate Language="C#" TargetLanguage="C#" Description="contains a creational factory for entity types." ResponseEncoding="UTF-8"  NoWarn="0108,0618,1572,1573,1574,0162,2002"%>
+<%@ Property Name="NameSpace" Type="System.String" Category="Data" Description="The project root Namespace." %>
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Microsoft.Practices.EnterpriseLibrary.Common;
+using Microsoft.Practices.EnterpriseLibrary.Caching;
+using Microsoft.Practices.EnterpriseLibrary.Caching.Configuration;
+using Microsoft.Practices.EnterpriseLibrary.Caching.BackingStoreImplementations;
+using Microsoft.Practices.EnterpriseLibrary.Common.Configuration;
+using Microsoft.Practices.EnterpriseLibrary.Caching.Cryptography.Configuration;
+
+namespace <%=NameSpace%>
+{
+	/// <summary>
+    /// Entity Cache provides a caching mechanism for entities on a by entity level.
+    /// </summary>
+    public static class EntityCache
+    {
+        private static volatile CacheManagerFactory cacheManagerFactory;
+        private static volatile CacheManager cacheManager;
+        private static string cacheManagerKey = "<%=NameSpace%>.EntityCache";
+		private static object syncObject = new object(); 
+		private static string configurationFile;
+        
+		/// <summary>
+        /// Gets the cache manager.
+        /// </summary>
+        /// <value>The cache manager.</value>		
+        public static CacheManager CacheManager
+        {
+            get{
+                if (cacheManager == null)
+                    cacheManager = (CacheManager) CacheManagerFactory.Create(cacheManagerKey);
+
+                return cacheManager;
+             }
+        }
+        
+		/// <summary>
+        /// Generates the configuration.
+        /// </summary>
+        /// <returns>DictionaryConfigurationSource to Configure the cache</returns>
+        internal static DictionaryConfigurationSource GenerateConfiguration()
+        {
+            DictionaryConfigurationSource sections = new DictionaryConfigurationSource();
+            sections.Add(CacheManagerSettings.SectionName, GenerateDefaultCacheManagerSettings());
+            return sections;
+        }
+
+		#region GenerateDefaultCacheManagerSettings
+        /// <summary>
+        /// Generates the default cache manager settings.
+        /// </summary>
+        /// <returns></returns>
+		private static CacheManagerSettings GenerateDefaultCacheManagerSettings()
+        {
+            CacheManagerSettings settings = new CacheManagerSettings();
+            settings.BackingStores.Add(new CacheStorageData("inMemoryWithEncryptor", typeof(NullBackingStore), "dpapiEncryptor"));
+            settings.EncryptionProviders.Add(new SymmetricStorageEncryptionProviderData("dpapiEncryptor", "dpapi1"));
+            settings.CacheManagers.Add(
+                new CacheManagerData(cacheManagerKey,
+                        10000, //Polling time
+                        1000, //Items to store
+                        100, //Items to remove 
+                        "inMemoryWithEncryptor"));
+            return settings;
+        }
+		#endregion 
+	    
+		#region ConfigurationFile
+		/// <summary>
+        /// Gets or sets the configuration file.
+        /// </summary>
+        /// <value>The configuration file.</value>
+        public static string ConfigurationFile
+		{
+			get
+			{ 	
+			    return configurationFile; 
+			}
+			set
+			{
+			    lock(syncObject)    
+			        configurationFile = value;
+			}
+		}
+		#endregion 
+		
+        #region CacheManagerFactory
+		/// <summary>
+        /// Gets or sets the cache manager factory.
+        /// </summary>
+        /// <value>The cache manager factory.</value>
+        public static CacheManagerFactory CacheManagerFactory
+        {
+            get {
+            	    if (cacheManagerFactory == null)
+					{
+						lock(syncObject)
+						{
+							IConfigurationSource configurationSource = null;
+							//From specified config
+							if (ConfigurationFile != null && System.IO.File.Exists(ConfigurationFile))
+							{
+								 configurationSource = new FileConfigurationSource(ConfigurationFile);
+                                 cacheManagerFactory = new CacheManagerFactory(configurationSource);
+							}
+							else
+                            {
+                                try
+                                {
+                                    //Try reading from default Configuration Source web/app config
+                                    IConfigurationSource userConfiguration = new SystemConfigurationSource();
+                                    cacheManagerFactory = new CacheManagerFactory(userConfiguration);
+									
+									//Test if CacheManagerKey is Configured
+                                    cacheManagerFactory.Create(CacheManagerKey);
+                                }
+                                catch(Exception)
+                                {
+                                    // Currently not configured, generate configuration
+                                    configurationSource = GenerateConfiguration();
+                                    cacheManagerFactory = new CacheManagerFactory(configurationSource);
+                                }
+							}
+						}
+					}
+                    return cacheManagerFactory; 
+                }
+            set { cacheManagerFactory = value; }
+        }
+		#endregion 
+		
+		#region CacheManagerKey
+		/// <summary>
+	    /// Assigns the Default CacheManagerKey To Be Used.
+	    /// </summary>
+	    public static string CacheManagerKey
+	    {
+	        get
+	        {
+	            return cacheManagerKey;
+	        }
+	        set
+	        {
+	            lock(syncObject)
+                {
+	                cacheManagerKey = value;
+                }
+	        }
+	    }
+		#endregion 
+		
+        #region RemoveItem
+        /// <summary>
+        /// Removes the item.
+        /// </summary>
+        /// <param name="id">The id.</param>
+		public static void RemoveItem(string id)
+        {
+            CacheManager.Remove(id);
+        }
+		#endregion 
+	
+        #region Flush Objects
+		/// <summary>
+        /// Flushes the cache manager.
+        /// </summary>
+        public static void FlushCacheManager()
+        {
+            cacheManager = null;
+        }
+
+        /// <summary>
+        /// Flushes the cache.
+        /// </summary>
+        public static void FlushCache()
+        {
+            CacheManager.Flush();
+        }
+        #endregion 
+	
+		#region AddCache
+        
+		/// <summary>
+        /// Adds the cache without a policy.
+        /// </summary>
+        /// <param name="id">The id.</param>
+        /// <param name="entity">The entity.</param>
+        public static void AddCache(string id, object entity)
+        {
+            CacheManager.Add(id, entity);
+        }
+
+        /// <summary>
+        /// Adds the cache.
+        /// </summary>
+        /// <param name="id">The id.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="_cachePolicy">The entity caching policy.</param>
+        public static void AddCache(string id, object entity, EntityCachePolicy _cachePolicy)
+        {
+            CacheManager.Add(id, entity);
+        }
+        
+		#endregion 
+	
+		#region GetItem
+        /// <summary>
+        /// Gets the item.
+        /// </summary>
+        /// <param name="id">The id.</param>
+        /// <returns></returns> 
+		public static T GetItem<T>(string id) where T : class
+        {
+            return CacheManager.GetData(id) as T;    
+        }
+        #endregion
+    
+	}
+
+    /// <summary>
+    /// Policy wrapper class
+    /// </summary>
+    public class EntityCachePolicy
+    {
+
+    }
+
+    /// <summary>
+    /// General features directing what the caching method is doing
+    /// </summary>
+    public enum EntityCacheOptions
+    {
+        /// <summary>
+        /// Just a standard cache retrieval call, apply Policy if provided and the item does not yet exist in cache.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Refresh the data in the cache.
+        /// </summary>
+        UpdateCache,
+        /// <summary>
+        /// Remove this key from the cache.
+        /// </summary>
+        RemoveFromCache
+    }
+}

--- a/Source/Entities/EntityInstanceBase.generated.cst
+++ b/Source/Entities/EntityInstanceBase.generated.cst
@@ -18,6 +18,7 @@
 <%@ Property Name="EntLibVersion" Type="MoM.Templates.EntLibVersion" Default="v5_0" Category="02. Framework Generation - Optional" Description="Indicates the Enterprise Library version to use. Options include v3.1, v5.0" %>
 
 <%@ Property Name="NameSpace" Optional="True" Type="System.String" Category="Style" Description="Object Namespace." %>
+<%@ Property Name="EntityCacheLayer" Optional="True" Type="MoM.Templates.CacheLayer" Default="None" Category="Options" Description="Should Caching be enabled for this entity." %>
 	
 <%@ Property Name="UsePartialClass" Type="System.Boolean" Default="true" Category="General" Description="Indicates if partial class should be generated." %>
 <%@ Property Name="EqualitySemantics" Type="MoM.Templates.EqualitySemantics" Default="Value" Category="02. Framework Generation - Optional" Description="Equality semantics used for Entity instances.  If 'Reference', default reference type semantics will be used (based on object identity).  If 'Value', Equals() and GetHashCode() will be overridden to use value semantics (based on object contents)." %>
@@ -88,6 +89,9 @@ using Microsoft.Practices.EnterpriseLibrary.Validation;
 <%}%>
 <% if (DotNetVersion  == MoM.Templates.DotNetFrameworkVersion.v4) {%>using System.ComponentModel.DataAnnotations;<%}%>
 using <%=NameSpace%>.Validation;
+<% if(EntityCacheLayer == MoM.Templates.CacheLayer.EntLib) {%>
+using Microsoft.Practices.EnterpriseLibrary.Caching;
+<%}%>
 #endregion
 
 namespace <%=NameSpace%>
@@ -101,7 +105,7 @@ namespace <%=NameSpace%>
 	[Serializable]
 	<% } %>
 	[DataObject, CLSCompliant(true)]
-	public abstract partial class <%=abstractClassName%> : EntityBase, <%=interfaceName%>, IEntityId<<%= keyClassName %>>, System.IComparable, System.ICloneable, ICloneableEx, IEditableObject, IComponent, INotifyPropertyChanged
+	public abstract partial class <%=abstractClassName%> : EntityBase, <%=interfaceName%>, IEntityId<<%= keyClassName %>>, System.IComparable, System.ICloneable, ICloneableEx, IEditableObject, IComponent, INotifyPropertyChanged<% if(EntityCacheLayer != MoM.Templates.CacheLayer.None) {%>, IEntityCacheItem<% } %>
 	{		
 		#region Variable Declarations
 		
@@ -1205,6 +1209,29 @@ WriteRelationshipPropertyString();
 			}
 		} 
 		#endregion
+        
+        <% if(EntityCacheLayer == MoM.Templates.CacheLayer.EntLib) {%>
+        #region Cache Attributes
+        
+        /// <summary>
+        /// Entity Cache Duration
+        /// </summary>
+        public TimeSpan EntityCacheDuration { get; set; }
+        /// <summary>
+        /// Entity Cache Priority
+        /// </summary>
+        public CacheItemPriority EntityCacheItemPriority { get; set; }
+        /// <summary>
+        /// Entity Cach Expiration
+        /// </summary>
+        public ICacheItemExpiration EntityCacheItemExpiration { get; set; }
+        /// <summary>
+        /// Entity Refresh Action
+        /// </summary>
+        public ICacheItemRefreshAction EntityCacheItemRefreshAction { get; set; }
+
+        #endregion
+        <% } %>
 			
 	} // End Class
 	

--- a/Source/Entities/IEntityCacheItem.cst
+++ b/Source/Entities/IEntityCacheItem.cst
@@ -1,4 +1,4 @@
-<%--
+﻿<%--
  * $Id: IEntity.cst,v 1.13 2006/02/27 22:09:40 bgjohnso Exp $
  * Last modified by $Author: bgjohnso $
  * Last modified at $Date: 2006/02/27 22:09:40 $
@@ -10,19 +10,23 @@
 <%@ Assembly Name="System.Design" %>
 
 <%@ Property Name="NameSpace" Optional="False" Type="System.String" Category="Style" Description="Object Namespace." %>
+<%@ Property Name="EntityCacheLayer" Optional="True" Type="MoM.Templates.CacheLayer" Default="None" Category="Style" Description="Which caching layer are we using." %>
+<% if (EntityCacheLayer != MoM.Templates.CacheLayer.SysRun) {%>
 using System;
 using System.Collections.Generic;
 using System.Text;
-
 using Microsoft.Practices.EnterpriseLibrary.Caching;
+<% } %>
 
 namespace <%=NameSpace%>
 {
     interface IEntityCacheItem
     {
+        <% if (EntityCacheLayer != MoM.Templates.CacheLayer.SysRun) {%>
         TimeSpan EntityCacheDuration{ get; set; }
         CacheItemPriority EntityCacheItemPriority { get; set;  }
         ICacheItemExpiration EntityCacheItemExpiration { get; set; }
         ICacheItemRefreshAction EntityCacheItemRefreshAction { get; set; }
+        <% } %>
     }
 }

--- a/Source/NetTiers.cst
+++ b/Source/NetTiers.cst
@@ -35,6 +35,7 @@
 <%@ Property Name="EqualitySemantics" Type="MoM.Templates.EqualitySemantics" Default="Value" Category="02. Framework Generation - Optional" Description="Equality semantics used for Entity instances.  If 'Reference', default reference type semantics will be used (based on object identity).  If 'Value', Equals() and GetHashCode() will be overridden to use value semantics (based on object contents)." %>
 <%@ Property Name="TimeStandard" Type="TimeStandardEnum" Default="Local" Category="02. Framework Generation - Optional" Description="Standard used for generating DateTime values. If 'UTC' DateTime is generated based on UtcNow. If 'Local' DateTime is generated based on DateTime.Now" %>
 <%@ Property Name="IsConnectionStringAzure" Type="System.Boolean" Default="False" Category="02. Framework Generation - Optional" Description="Indicates if at runtime the netTiersConnectionString is read from Window Azure's ServiceConfiguration.cscfg or from Web.config/app.config." %>
+<%@ Property Name="EntityCacheLayer" Type="MoM.Templates.CacheLayer" Default="None" Category="02. Framework Generation - Optional" Description="Indicates if the Cache code should be written for the enabled CacheTables entities using Enterprise Library or System.Runtime.Caching." %>
 
 <%-- 3. Namespaces Category --%>
 <%@ Property Name="BusinessLogicLayerNameSpace" Type="System.String" Category="03. Namespaces - Required" Description="The sub namespace that is added to the root namespace for the entities." Default="Entities" Optional="False" %>
@@ -128,6 +129,7 @@
 	private TableSchemaCollection templateSourceTables;
 	private ViewSchemaCollection templateSourceViews;
 	private TableSchemaCollection templateEnumTables;
+	private TableSchemaCollection templateCacheTables;
    
 	#endregion
 	
@@ -289,6 +291,24 @@
 		set
 		{			
 			this.templateEnumTables = value;
+		}
+	}
+	
+	[Category("01b. Filter by Individual Objects - Optional")]
+	[Description("The tables to tag for caching. Or for use by Entity tracking code.")]
+	[Optional, NotChecked]
+	public TableSchemaCollection CacheTables
+	{
+		get
+		{
+			if (this.templateCacheTables != null && this.templateCacheTables.Count > 0 )
+				return this.templateCacheTables;
+			else
+				return null;
+		}
+		set
+		{			
+			this.templateCacheTables = value;
 		}
 	}
 	
@@ -691,6 +711,7 @@
 		#if CodeSmith50
 		this.SetPropertyAttribute("SourceTables", "DeepLoad", "True");
 		this.SetPropertyAttribute("EnumTables", "DeepLoad", "True");
+		this.SetPropertyAttribute("CacheTables", "DeepLoad", "True");
 		this.SetPropertyAttribute("SourceViews", "DeepLoad", "True");
 		#endif
 		base.OnInit();
@@ -1055,7 +1076,11 @@
 		}
 		#endregion Check the enum tables format (int + text)	
 		
-		#region Create directories and copy dependencies
+		#region Check cache table object
+		if (templateCacheTables == null) templateCacheTables = new TableSchemaCollection();	
+		#endregion Check cache table object
+
+        #region Create directories and copy dependencies
 		_CurrentPhase = "CREATING FOLDERS AND COPYING DEPENDENCIES ";
 		DebugWriteLine("Current Phase: "+_CurrentPhase);
 		
@@ -1434,15 +1459,25 @@
 		//----------------------------------------------------------------------------------------------------------------------------------------------
 		XmlElement iEntityCacheItemNode = AddFileNode(commonNode, "IEntityCacheItem.cs");
 		this.GetTemplate("IEntityCacheItem.cst").SetProperty("NameSpace", BLLNameSpace);
+ 		this.GetTemplate("IEntityCacheItem.cst").SetProperty("EntityCacheLayer", EntityCacheLayer);
 		this.RenderToFile("IEntityCacheItem.cst", rootPathBLL + "\\IEntityCacheItem.cs", true);
 	
 		//----------------------------------------------------------------------------------------------------------------------------------------------
 		//-- Entity EntityCache file
 		//----------------------------------------------------------------------------------------------------------------------------------------------
-		XmlElement iEntityCacheNode = AddFileNode(commonNode, "EntityCache.cs");
-		this.GetTemplate("EntityCache.cst").SetProperty("NameSpace", BLLNameSpace);
-		this.RenderToFile("EntityCache.cst", rootPathBLL + "\\EntityCache.cs", true);
-		
+        if(EntityCacheLayer == MoM.Templates.CacheLayer.SysRun)
+        {
+    		XmlElement iEntityCacheNode = AddFileNode(commonNode, "EntityCache.cs");
+    		this.GetTemplate("EntityCache.cst").SetProperty("NameSpace", BLLNameSpace);
+    		this.RenderToFile("EntityCache.cst", rootPathBLL + "\\EntityCache.cs", true);
+        }
+        else
+        {
+    		XmlElement iEntityCacheNode = AddFileNode(commonNode, "EntityCache.cs");
+    		this.GetTemplate("EntityCache_EntLib.cst").SetProperty("NameSpace", BLLNameSpace);
+    		this.RenderToFile("EntityCache_EntLib.cst", rootPathBLL + "\\EntityCache.cs", true);
+        }
+
 		//----------------------------------------------------------------------------------------------------------------------------------------------
 		//-- Entity IEntityLocator file
 		//----------------------------------------------------------------------------------------------------------------------------------------------
@@ -2917,6 +2952,7 @@
 		this.GetTemplate(projectTemplate).SetProperty("SourceTables", templateSourceTables);
 		this.GetTemplate(projectTemplate).SetProperty("SourceViews", templateSourceViews);
 		this.GetTemplate(projectTemplate).SetProperty("EnumTables", templateEnumTables);
+		this.GetTemplate(projectTemplate).SetProperty("CacheTables", templateCacheTables);
 	
 		this.GetTemplate(projectTemplate).SetProperty("SignAssembly", SignAssembly);
 		this.GetTemplate(projectTemplate).SetProperty("OutputDirectory", OutputDirectory);
@@ -3885,6 +3921,18 @@
 				this.GetTemplate("EntityInstanceBase.generated.cst").SetProperty("EqualitySemantics", EqualitySemantics);
 				this.GetTemplate("EntityInstanceBase.generated.cst").SetProperty("ValidationType", ValidationType);
                 this.GetTemplate("EntityInstanceBase.generated.cst").SetProperty("EntLibVersion", EntLibVersion);
+                if (templateCacheTables.Contains(SourceTable.Owner, SourceTable.Name))
+				{
+                    // Generate the Interface stuff whether or not the user wants the full Caching system.
+                    if (EntityCacheLayer == MoM.Templates.CacheLayer.None)
+                        this.GetTemplate("EntityInstanceBase.generated.cst").SetProperty("EntityCacheLayer", MoM.Templates.CacheLayer.EntLib);
+                    else
+                        this.GetTemplate("EntityInstanceBase.generated.cst").SetProperty("EntityCacheLayer", EntityCacheLayer);
+                }
+                else
+                {
+                    this.GetTemplate("EntityInstanceBase.generated.cst").SetProperty("EntityCacheLayer", MoM.Templates.CacheLayer.None);
+                }
 				
 				this.RenderToFile("EntityInstanceBase.generated.cst", rootPathBLL + "\\" + GetClassName(SourceTable, ClassNameFormat.PartialAbstract) + ".cs", true);
 				AddExecutionTime(boBaseNode);
@@ -4027,6 +4075,7 @@
 					this.GetTemplate("ComponentServiceBase.cst").SetProperty("IncludeCustoms", IncludeCustoms);
 					this.GetTemplate("ComponentServiceBase.cst").SetProperty("CustomNonMatchingReturnType", CustomNonMatchingReturnType);				
 					this.GetTemplate("ComponentServiceBase.cst").SetProperty("ProcedurePrefix", ProcedurePrefix.Replace(" ", ""));
+                    this.GetTemplate("ComponentServiceBase.cst").SetProperty("CreateEntityCache", (templateCacheTables.Contains(SourceTable.Owner, SourceTable.Name) && EntityCacheLayer != MoM.Templates.CacheLayer.None));
 		
 					this.RenderToFile("ComponentServiceBase.cst", rootPathComponents + "\\" + GetClassName(SourceTable, ClassNameFormat.PartialAbstractService) + ".cs", true);
 		

--- a/Source/TemplateLib/CommonSqlCode.cs
+++ b/Source/TemplateLib/CommonSqlCode.cs
@@ -1,4 +1,4 @@
-using CodeSmith.Engine;
+﻿using CodeSmith.Engine;
 using SchemaExplorer;
 using System;
 using System.Windows.Forms.Design;
@@ -6415,6 +6415,18 @@ CREATE\s+PROC(?:EDURE)?                               # find the start of the st
             }
             return StrToAbbrev;
         }
+        
+        public string GetCacheFunctionParameters(MoM.Templates.DotNetFrameworkVersion DotNetVersion)
+        {
+            if(DotNetVersion == MoM.Templates.DotNetFrameworkVersion.v2 || DotNetVersion == MoM.Templates.DotNetFrameworkVersion.v3 || DotNetVersion == MoM.Templates.DotNetFrameworkVersion.v3_5)
+            {
+                return "EntityCacheOptions _cacheOptions, EntityCachePolicy _cachePolicy";
+            }
+            else
+            {
+                return "EntityCacheOptions _cacheOptions = EntityCacheOptions.None, EntityCachePolicy _cachePolicy = null";
+            }
+        }
     }
 
     #region Retry
@@ -6454,6 +6466,22 @@ CREATE\s+PROC(?:EDURE)?                               # find the start of the st
         //v4_1 = 4
         /// <summary>Use Enterprise Library version 5.0</summary>
         v5_0 = 8
+    }
+
+    #endregion
+
+    #region Caching Layer
+    /// <summary>
+    /// Enterprise Library versions
+    /// </summary>
+    public enum CacheLayer : byte
+    {
+        /// <summary>Do not generate caching layer</summary>
+        None = 0,
+        /// <summary>Use Enterprise Library version</summary>
+        EntLib = 1,
+        /// <summary>System.Runtime.Caching</summary>
+        SysRun = 2
     }
 
     #endregion

--- a/Source/TemplateLib/CommonSqlCode.cs
+++ b/Source/TemplateLib/CommonSqlCode.cs
@@ -6424,7 +6424,7 @@ CREATE\s+PROC(?:EDURE)?                               # find the start of the st
             }
             else
             {
-                return "EntityCacheOptions _cacheOptions = EntityCacheOptions.None, EntityCachePolicy _cachePolicy = null";
+                return "EntityCacheOptions _cacheOptions, EntityCachePolicy _cachePolicy = null";
             }
         }
     }

--- a/Source/TemplateLib/CreateTemplates.cs
+++ b/Source/TemplateLib/CreateTemplates.cs
@@ -1,4 +1,4 @@
-		#region Templates
+﻿		#region Templates
 
 			CodeTemplates.Add("NetTiersMapInstance.Internal.cst", base.CreateTemplate<MappingInstance>()); this.PerformStep();
 			CodeTemplates.Add("vsnet2005.project.cst", base.CreateTemplate<vsnet2005Project>()); this.PerformStep();
@@ -29,6 +29,7 @@
 			CodeTemplates.Add("EntityFactory.cst", base.CreateTemplate<EntityFactory>()); this.PerformStep();
 			CodeTemplates.Add("EntityFactoryBase.cst", base.CreateTemplate<EntityFactoryBase>()); this.PerformStep();
 			CodeTemplates.Add("EntityCache.cst", base.CreateTemplate<EntityCache>()); this.PerformStep();
+			CodeTemplates.Add("EntityCache_EntLib.cst", base.CreateTemplate<EntityCache_EntLib>()); this.PerformStep();
 			CodeTemplates.Add("EntityLocator.cst", base.CreateTemplate<EntityLocator>()); this.PerformStep();
             CodeTemplates.Add("EntityLocator_EntLib5.cst", base.CreateTemplate<EntityLocator_EntLib5>()); this.PerformStep();
 			CodeTemplates.Add("EntityManager.cst", base.CreateTemplate<EntityManager>()); this.PerformStep();

--- a/Source/TemplateLib/FrameworkTemplates.cst
+++ b/Source/TemplateLib/FrameworkTemplates.cst
@@ -1,4 +1,4 @@
-<%@ Register Name="MappingInstance" Template="../SchemaMapping/NetTiersMapInstance.Internal.cst" MergeProperties="False" ExcludeProperties="" %>
+﻿<%@ Register Name="MappingInstance" Template="../SchemaMapping/NetTiersMapInstance.Internal.cst" MergeProperties="False" ExcludeProperties="" %>
 <%@ Register Name="vsnet2005Project" Template="../VisualStudio/vsnet2005.project.cst" MergeProperties="False" ExcludeProperties="" %>
 <%@ Register Name="vsnet2005Solution" Template="../VisualStudio/vsnet2005.solution.cst" MergeProperties="False" ExcludeProperties="" %>
 <%@ Register Name="vsnet2005Vsmdi" Template="../VisualStudio/vsnet2005.vsmdi.cst" MergeProperties="False" ExcludeProperties="" %>
@@ -26,6 +26,7 @@
 <%@ Register Name="EntityFactory" Template="../Entities/EntityFactory.cst" MergeProperties="False" ExcludeProperties="" %>
 <%@ Register Name="EntityFactoryBase" Template="../Entities/EntityFactoryBase.cst" MergeProperties="False" ExcludeProperties="" %>
 <%@ Register Name="EntityCache" Template="../Entities/EntityCache.cst" MergeProperties="False" ExcludeProperties="" %>
+<%@ Register Name="EntityCache_EntLib" Template="../Entities/EntityCache_EntLib.cst" MergeProperties="False" ExcludeProperties="" %>
 <%@ Register Name="EntityLocator" Template="../Entities/EntityLocator.cst" MergeProperties="False" ExcludeProperties="" %>
 <%@ Register Name="EntityLocator_EntLib5" Template="../Entities/EntityLocator_EntLib5.cst" MergeProperties="False" ExcludeProperties="" %>
 <%@ Register Name="EntityManager" Template="../Entities/EntityManager.cst" MergeProperties="False" ExcludeProperties="" %>

--- a/Source/VisualStudio/entlib.v5_0.config.cst
+++ b/Source/VisualStudio/entlib.v5_0.config.cst
@@ -3,6 +3,7 @@
 <%@ Property Name="NameSpace" Type="System.String" Category="Data" Description="Namespace." %>
 <%@ Property Name="BLLNameSpace" Type="System.String" Category="Data" Description="BLL Namespace." %>
 <%@ Property Name="EntLibVersion" Type="MoM.Templates.EntLibVersion" Default="v5_0" Category="02. Framework Generation - Optional" Description="Indicates the Enterprise Library version to use. Options include v3.1, v5.0" %>
+<%@ Property Name="EntityCacheLayer" Type="MoM.Templates.CacheLayer" Default="None" Category="02. Framework Generation - Optional" Description="Indicates if the Cache code should be written for the enabled CacheTables entities using Enterprise Library or System.Runtime.Caching." %>
 
 <%@ Assembly Name="SchemaExplorer" %>
 <%@ Assembly Name="System.Design" %>
@@ -86,6 +87,15 @@
 			</add>
 		</exceptionPolicies>
 	</exceptionHandling>
+    <%if(EntityCacheLayer == MoM.Templates.CacheLayer.SysRun) { %>
+    <system.runtime.caching>
+        <memoryCache>
+            <namedCaches>
+                <add name="<%= BLLNameSpace %>.EntityCache" cacheMemoryLimitMegabytes="0" physicalMemoryLimitPercentage="0" pollingInterval="00:02:00" />
+            </namedCaches>
+        </memoryCache>
+    </system.runtime.caching>
+    <%} else { %>
 	<cachingConfiguration defaultCacheManager="<%= BLLNameSpace %>.EntityCache">
 		<cacheManagers>
 			<add expirationPollFrequencyInSeconds="60" maximumElementsInCacheBeforeScavenging="1000"
@@ -97,4 +107,5 @@
 			  name="Null Storage" />
 		</backingStores>
 	</cachingConfiguration>
+    <%} %>
 </configuration>

--- a/Source/VisualStudio/vsnet2005.project.cst
+++ b/Source/VisualStudio/vsnet2005.project.cst
@@ -73,6 +73,7 @@
 <%@ Property Name="VisualStudioVersion" Type="MoM.Templates.VSNetVersion" Default="v2013" Category="02. Framework Generation - Optional" Description="Indicates the Version of Visual Studio to target. Options include v2005, v2008 and v2010" %>
 <%@ Property Name="DotNetVersion" Type="MoM.Templates.DotNetFrameworkVersion" Default="v4_5" Category="02. Framework Generation - Optional" Description="Indicates the Version of Dot Net to target. Options include v2, v3 and v3.5" %>
 <%@ Property Name="IsConnectionStringAzure" Type="System.Boolean" Default="False" Category="02. Framework Generation - Optional" Description="Indicates if at runtime the netTiersConnectionString is read from Window Azure's ServiceConfiguration.cscfg or from Web.config/app.config." %>
+<%@ Property Name="EntityCacheLayer" Type="MoM.Templates.CacheLayer" Default="None" Category="02. Framework Generation - Optional" Description="Indicates if the Cache code should be written for the enabled CacheTables entities using Enterprise Library or System.Runtime.Caching." %>
 
 <%@ Assembly Name="SchemaExplorer" %>
 <%@ Assembly Name="System.Design" %>
@@ -287,7 +288,10 @@
     <Reference Include="System.Xml"/>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
-	<% if ( IncludeWCFDataAttributes ) { %>    
+    <% if( EntityCacheLayer == MoM.Templates.CacheLayer.SysRun) { %>
+    <Reference Include="System.Runtime.Caching" />
+    <% } %>
+    <% if ( IncludeWCFDataAttributes ) { %>    
     <% if (VisualStudioVersion == MoM.Templates.VSNetVersion.v2010 || VisualStudioVersion == MoM.Templates.VSNetVersion.v2012 || VisualStudioVersion == MoM.Templates.VSNetVersion.v2013) { %>
     <Reference Include="System.Runtime.Serialization" />
     <% } else { %>
@@ -317,6 +321,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath><%= LibraryPath %>\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
     </Reference>    
+    <% if( EntityCacheLayer != MoM.Templates.CacheLayer.SysRun) { %>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Caching, <%= entlibVersionText %>">
       <SpecificVersion>False</SpecificVersion>
       <HintPath><%= LibraryPath %>\Microsoft.Practices.EnterpriseLibrary.Caching.dll</HintPath>
@@ -325,6 +330,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath><%= LibraryPath %>\Microsoft.Practices.EnterpriseLibrary.Caching.Cryptography.dll</HintPath>
     </Reference>
+    <% } %>
     <% if(includeObjectBuilder) { %>
 	<Reference Include="Microsoft.Practices.<%= GetEntLibOBClassName(EntLibVersion)%>, <%= GetEntLibOBVersionSignature(EntLibVersion) %>">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
1. added feature to auto gen entity tracking implementation code.
2. added cache methods for indexes, foreign keys, getall, and custom
sprocs.
3. Added option to upgrade caching code to System.Runtime.

-- The naming convention for the new methods are: GetCacheBy<IndexName>; an alternate name contemplated was CacheBy<IndexName>.