### PR TITLE
SET ANSI_NULLS switch for SQLClient

### DIFF
--- a/Source/DataAccessLayer.SqlClient/StoredProceduresXml.cst
+++ b/Source/DataAccessLayer.SqlClient/StoredProceduresXml.cst
@@ -20,6 +20,8 @@
 <%@ Property Name="IncludeManyToMany" Type="System.Boolean" Default="True" Category="Options" Description="If true select statements will be generated for any many to many relationship." %>
 <%@ Property Name="UseTimestampConcurrency" Type="System.Boolean" Default="True" Category="Options" Description="If this is set to True, Update and Delete will throw DbConcurrencyException when the timestamp doesn't match current." %>
 
+<%@ Property Name="SetAnsiNullsOn" Type="System.Boolean" Default="False" Category="Options" Description="If this is set to True, SET ANSI_NULLS will be ON instead of OFF." %>
+
 <%@ Property Name="IsolationLevel" Type="TransactionIsolationLevelEnum" Default="None" Category="Options" Description="Isolation level to use in generated procedures." %>
 <%@ Property Name="ExcludeFields" Type="System.String[]" Optional="True" Category="Options" Description="Enter a list of fields to exclude from parameter generation" %>
 
@@ -63,7 +65,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <?xml-stylesheet type='text/xsl' href="scriptsql.xsl"?>
 <root xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-<database includeDrop="<%=this.IncludeDrop.ToString().ToLower()%>"><%=(SourceTables.Count > 0 ? SourceTables[0].Database.Name : SourceViews[0].Database.Name)%></database>
+<database includeDrop="<%=this.IncludeDrop.ToString().ToLower()%>" setAnsiNulls="<%=(this.SetAnsiNullsOn == true) ? "ON" : "OFF" %>"><%=(SourceTables.Count > 0 ? SourceTables[0].Database.Name : SourceViews[0].Database.Name)%></database>
 <procedures>
 <%
 if ( IncludeDrop &&

--- a/Source/DataAccessLayer.SqlClient/scriptsql.xsl
+++ b/Source/DataAccessLayer.SqlClient/scriptsql.xsl
@@ -14,7 +14,7 @@ USE [<xsl:value-of select="/root/database"/>]
 GO
 SET QUOTED_IDENTIFIER ON 
 GO
-SET ANSI_NULLS OFF 
+SET ANSI_NULLS <xsl:value-of select="/root/database/@setAnsiNulls"/>
 GO
 <xsl:apply-templates select="//procedures/procedure[not(@skip)]"/>
 </xsl:template>
@@ -44,7 +44,7 @@ SET QUOTED_IDENTIFIER ON
 GO
 SET NOCOUNT ON
 GO
-SET ANSI_NULLS OFF 
+SET ANSI_NULLS <xsl:value-of select="/root/database/@setAnsiNulls"/>
 GO
 </xsl:template>
 

--- a/Source/NetTiers.cst
+++ b/Source/NetTiers.cst
@@ -94,6 +94,7 @@
 <%@ Property Name="IncludeRelations" Type="System.Boolean" Default="True" Category="07. CRUD - Advanced" Description="If true select statements will be generated for any many to many relationship." %>
 <%@ Property Name="IsolationLevel" Type="TransactionIsolationLevelEnum" Default="None" Category="07. CRUD - Advanced" Description="Isolation level to use in generated procedures." %>
 <%@ Property Name="UseTimestampConcurrency" Type="System.Boolean" Default="True" Category="07. CRUD - Advanced" Description="If this is set to True, Update and Delete will throw DbConcurrencyException when the timestamp doesn't match current." %>
+<%@ Property Name="SetAnsiNullsOn" Type="System.Boolean" Default="False" Category="07. CRUD - Advanced" Description="If this is set to True, SET ANSI_NULLS will be ON instead of OFF. Applies to SqlClient and eventually SqlCeClient" %>
 
 <%-- Style of stored procedures --%>
 <%@ Property Name="InsertSuffix" Type="System.String" Default="_Insert" Category="08. Stored procedures - Advanced" Description="Suffix to use for all generated INSERT stored procedures." %>
@@ -1833,6 +1834,7 @@
 			this.GetTemplate(xmlTemplateName).SetProperty("IncludeGetListByIX", IncludeGetListByIX);
 			this.GetTemplate(xmlTemplateName).SetProperty("IncludeFind", IncludeFind);
 			this.GetTemplate(xmlTemplateName).SetProperty("IncludeDatabaseFeatures", IncludeDatabaseFeatures);
+			this.GetTemplate(xmlTemplateName).SetProperty("SetAnsiNullsOn", SetAnsiNullsOn);
 			
 			this.GetTemplate(xmlTemplateName).SetProperty("IsolationLevel", IsolationLevel);
 			this.GetTemplate(xmlTemplateName).SetProperty("InsertSuffix", InsertSuffix);


### PR DESCRIPTION
Allow ANSI_NULLS to be turned on or off during auto generation on SQL
Server.

It allows the option to reverse a change that was made a long time ago to NetTiers.
 
The ANSI_NULLS database feature, when turned off, causes Microsoft SQL server to behave more like .NET and treat a NULL value as a value instead of as nothing.  Many developers like this although it is considered poor practice.  There are some features of SQL Server, such as indexed views, which are not compatible with this feature being turned off.  So adding this switch allows us to re-gain the power of the database in this area without NetTiers blowing up when we use it.