### PR TITLE
bugFix: additional check for source properties

### DIFF
--- a/Source/Components/ComponentBase.cst
+++ b/Source/Components/ComponentBase.cst
@@ -207,7 +207,7 @@ namespace <%=NameSpace%>
                 <% if (IncludeGetListByFK && cols[x].IsForeignKeyMember) { 
                     foreach(TableKeySchema tableKey in SourceTable.ForeignKeys)
                     {
-                        if (!SourceTables.Contains(tableKey.PrimaryKeyTable)) 
+                        if (!SourceTables.Contains(tableKey.PrimaryKeyTable) || !tableKey.ForeignKeyMemberColumns.Contains(cols[x]))
                             continue;
                 %>
                 <%= GetPropertyName(cols[x])%>Source = null;


### PR DESCRIPTION
It's necessary to check not just that the PrimaryKeyTable is included in SourceTables but even if the current column is included in the foreign key.
Without this check you ends up having multiple duplicated lines for the same property, if the table have more than one foreign key.