### PR TITLE
Refresh views with just chosen

### DIFF
--- a/Source/NetTiers.cst
+++ b/Source/NetTiers.cst
@@ -1505,10 +1505,12 @@
 
                     // Now that the sql has been executed, refresh the view meta data in case in changed.
                     SourceDatabase.Refresh();
+                    
+                    ViewSchemaCollection temp_templateSourceViews = templateSourceViews;
                     templateSourceViews = new ViewSchemaCollection();
-                    for (int i=0; i < SourceDatabase.Views.Count; i++)
+                    for (int i=0; i < temp_templateSourceViews.Count; i++)
                     {
-                        templateSourceViews.Add(SourceDatabase.Views[i]);
+                        templateSourceViews.Add(SourceDatabase.Views[temp_templateSourceViews[i].Name]);
                     }
                 }
                 catch(System.Data.SqlClient.SqlException sex)

--- a/Source/NetTiers.cst
+++ b/Source/NetTiers.cst
@@ -1506,11 +1506,9 @@
                     // Now that the sql has been executed, refresh the view meta data in case in changed.
                     SourceDatabase.Refresh();
                     
-                    ViewSchemaCollection temp_templateSourceViews = templateSourceViews;
-                    templateSourceViews = new ViewSchemaCollection();
-                    for (int i=0; i < temp_templateSourceViews.Count; i++)
+                    for (int i=0; i < templateSourceViews.Count; i++)
                     {
-                        templateSourceViews.Add(SourceDatabase.Views[temp_templateSourceViews[i].Name]);
+                        templateSourceViews[i] = SourceDatabase.Views[templateSourceViews[i].Name];
                     }
                 }
                 catch(System.Data.SqlClient.SqlException sex)


### PR DESCRIPTION
The ExecuteViews feature has a bug in it where after execution the view list is populated with all views from the database, not just the chosen views.  This causes code to be generated for all the views, not just the desired ones.

This commit fixes that bug, so only the chosen views remain chosen.