### PR TITLE
ANSI_NULLS ON and reflection fixes

### DIFF
--- a/Source/DataAccessLayer.SqlClient/StoredProceduresXml.cst
+++ b/Source/DataAccessLayer.SqlClient/StoredProceduresXml.cst
@@ -609,7 +609,6 @@ GO
   			%>
 			</parameters>
 			<body><![CDATA[
-				SET ANSI_NULLS OFF
 				<%= GetSetTransactionIsolationLevelStatement() %>
 				SELECT
 					<% for (int i = 0; i < cols.Count; i++) { %>
@@ -623,7 +622,6 @@ GO
 					<% } %>
 				
 				SELECT @@ROWCOUNT
-				SET ANSI_NULLS ON
 			]]></body>
 		</procedure>
 <%
@@ -656,6 +654,7 @@ GO
   				}%>
 			</parameters>
 			<body><![CDATA[
+				<%= GetSetTransactionIsolationLevelStatement() %>
 				SELECT
 					<% for (int i = 0; i < cols.Count; i++) { %>
 					[<%= cols[i].Name %>]<% if (i < cols.Count - 1) { %>,<% } %>

--- a/Source/DataAccessLayer/Utility.cst
+++ b/Source/DataAccessLayer/Utility.cst
@@ -563,7 +563,7 @@ namespace <%=DALNameSpace%>
         /// Specify whether command data exists in this excaption
         /// </summary>
         /// 
-        public bool HasCommandData = false;
+        public bool HasCommandData { get; set; }
 
         /// <summary>
         /// The DbCommand object CommandText
@@ -593,16 +593,23 @@ namespace <%=DALNameSpace%>
         /// <summary>
         /// How long the Data call was running for
         /// </summary>
-        public long ElapsedMilliseconds = 0;
+        public long ElapsedMilliseconds { get; set; }
 
         /// <summary>
         /// Which execute attempt triggered this error
         /// </summary>
-        public int Attempt = 0;
+        public int Attempt { get; set; }
 
         #endregion
 
         #region Constructors
+
+        /// <summary>
+        /// Constructor to populate the base exception
+        /// </summary>
+        public NetTiersDataException() : base()
+        {
+        }
 
         /// <summary>
         /// Constructor to populate the base exception


### PR DESCRIPTION
Fixes to bring the sprocs in line with the standards so they work correctly with the ANSI_NULLS toggle.

Also some minor adjustments to the NetTiersDataException object for easier use with reflection and serialization.